### PR TITLE
add glam feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,18 @@ readme = "README.md"
 keywords = ["3D", "graphics", "algorithm", "tangent"]
 license = "MIT/Apache-2.0"
 
+[features]
+default = ["nalgebra"]
+
 [badges]
 travis-ci = { repository = "gltf-rs/mikktspace" }
 
 [dependencies]
-nalgebra = "0.19.0"
+nalgebra = { version = "0.25.0", optional = true }
+glam = { version = "0.13.0", optional = true }
 
 [[example]]
 name = "generate"
+
+[dev-dependencies]
+nalgebra = "0.25"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
 mod generated;
 
-use nalgebra::{Vector2, Vector3};
+#[cfg(feature = "nalgebra")]
+type Vec3 = nalgebra::Vector3<f32>;
+#[cfg(feature = "nalgebra")]
+type Vec2 = nalgebra::Vector2<f32>;
+
+#[cfg(feature = "glam")]
+type Vec3 = glam::Vec3;
+#[cfg(feature = "glam")]
+type Vec2 = glam::Vec2;
 
 /// The interface by which mikktspace interacts with your geometry.
 pub trait Geometry {
@@ -57,18 +65,22 @@ pub fn generate_tangents<I: Geometry>(geometry: &mut I) -> bool {
     unsafe { generated::genTangSpace(geometry, 180.0) }
 }
 
-fn get_position<I: Geometry>(geometry: &mut I, index: usize) -> Vector3<f32> {
+fn get_position<I: Geometry>(geometry: &mut I, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
     geometry.position(face, vert).into()
 }
 
-fn get_tex_coord<I: Geometry>(geometry: &mut I, index: usize) -> Vector3<f32> {
+fn get_tex_coord<I: Geometry>(geometry: &mut I, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
-    let tex_coord: Vector2<f32> = geometry.tex_coord(face, vert).into();
-    tex_coord.insert_row(2, 1.0)
+    let tex_coord: Vec2 = geometry.tex_coord(face, vert).into();
+    #[cfg(feature = "nalgebra")]
+    let val = tex_coord.insert_row(2, 1.0);
+    #[cfg(feature = "glam")]
+    let val = tex_coord.extend(1.0);
+    val
 }
 
-fn get_normal<I: Geometry>(geometry: &mut I, index: usize) -> Vector3<f32> {
+fn get_normal<I: Geometry>(geometry: &mut I, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
     geometry.normal(face, vert).into()
 }


### PR DESCRIPTION
This adds a `glam` feature which uses the [glam](https://github.com/bitshifter/glam-rs/) crate instead of `nalgebra` to reduce the amount of dependencies for crates not using `nalgebra` (specifically the [bevy engine](github.com/bevyengine/bevy)).
Let me know if this is something you'd merge, otherwise if it is okay if I fork this repo and publish it using glam (#20).